### PR TITLE
[AB#36058] Add layer-enabled monorepo serverless4 workflows for stg, sbx and prd

### DIFF
--- a/.github/workflows/monorepo-api-deploy-aws-prd-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-prd-serverless4-layer.yml
@@ -1,0 +1,121 @@
+name: monorepo-api-deploy-prd-layer
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_PRD:
+        required: true
+      DATABASE_PASSWORD_PRD:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_PRD:
+        required: false
+jobs:
+  deploy-prd:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_PRD}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_PRD}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_PRD}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_PRD}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_PRD }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_PRD }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_PRD}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_PRD}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_PRD}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_PRD}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_PRD}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_PRD}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_PRD}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_PRD}}
+      DD_API_KEY: ${{secrets.DD_API_KEY}}
+      DD_ENABLED: ${{vars.DD_ENABLED_PRD}}
+      ENV: ${{vars.ENV_PRD}}
+      AWS_LAMBDA_EXEC_WRAPPER: '/opt/datadog_wrapper'
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_PRD}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_PRD}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_PRD}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_PRD}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_PRD }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_PRD }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_PRD }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+          npm config set -- '//f3capital.jfrog.io/artifactory/api/npm/f3capital-npm/:_auth' "${{secrets.ARTIFACTORY_AUTH}}"
+          npm config set -- 'email' "${{vars.ARTIFACTORY_EMAIL}}"
+          echo "always-auth=true" >> ~/.npmrc
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_PRD }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Production Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_PRD}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_PRD}}
+          export AWS_REGION=${{vars.AWS_REGION_PRD}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_PRD}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-serverless4-layer.yml
@@ -1,0 +1,120 @@
+name: api-deploy-sbx-layer
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_SBX:
+        required: true
+      DATABASE_PASSWORD_SBX:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_SBX:
+        required: false
+jobs:
+  deploy-sbx:
+    if: github.ref == 'refs/heads/sbx'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_SBX}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_SBX}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_SBX}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_SBX}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_SBX }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_SBX }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_SBX}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_SBX}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_SBX}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_SBX}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_SBX}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_SBX}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_SBX}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_SBX}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_SBX}}
+      ENV: ${{vars.ENV_SBX}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_SBX}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_SBX}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_SBX}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_SBX}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+          npm config set -- '//f3capital.jfrog.io/artifactory/api/npm/f3capital-npm/:_auth' "${{secrets.ARTIFACTORY_AUTH}}"
+          npm config set -- 'email' "${{vars.ARTIFACTORY_EMAIL}}"
+          echo "always-auth=true" >> ~/.npmrc
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_SBX }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Sandbox Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_SBX}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_SBX}}
+          export AWS_REGION=${{vars.AWS_REGION_SBX}}
+          npm i -g serverless
+          sls deploy --force --stage ${{vars.ENV_SBX}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-stg-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-serverless4-layer.yml
@@ -1,0 +1,120 @@
+name: monorepo-api-deploy-stg-layer
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_STG:
+        required: true
+      DATABASE_PASSWORD_DEV:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_DEV:
+        required: false
+jobs:
+  deploy-stg:
+    if: github.ref == 'refs/heads/stg'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_DEV}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_DEV}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_DEV}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_DEV}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_DEV }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_DEV }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_DEV}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_DEV}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_DEV}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_STG}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_STG}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_STG}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_STG}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_STG}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_STG}}
+      ENV: ${{vars.ENV_STG}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_STG}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_STG}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_STG}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_STG}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+          npm config set -- '//f3capital.jfrog.io/artifactory/api/npm/f3capital-npm/:_auth' "${{secrets.ARTIFACTORY_AUTH}}"
+          npm config set -- 'email' "${{vars.ARTIFACTORY_EMAIL}}"
+          echo "always-auth=true" >> ~/.npmrc
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_STG }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Staging Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_STG}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_STG}}
+          export AWS_REGION=${{vars.AWS_REGION_STG}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_STG}} --region $AWS_REGION


### PR DESCRIPTION
## Contexto

O workflow `monorepo-api-deploy-aws-dev-serverless4-layer.yml` já existe no master e habilita o deploy de Lambda layers no **dev** (usado pelo contributions). Faltavam os canais **stg**, **sbx** e **prd**.

## Mudança

Cria os 3 novos workflows, cada um = cópia do respectivo base `monorepo-api-deploy-aws-<canal>-serverless4.yml` + o step **Install layer dependencies**:

```yaml
- name: Install layer dependencies
  working-directory: ${{ inputs.WORKING_DIRECTORY }}
  run: |
    if [ -d "layer" ]; then
      for dir in layer/*/; do
        if [ -f "$dir/package.json" ]; then
          (cd "$dir" && yarn install)
        fi
      done
    fi
```

- Arquivos: `monorepo-api-deploy-aws-{stg,sbx,prd}-serverless4-layer.yml`
- O step é **idêntico** ao já validado no dev.
- **Condicional a `layer/` existir** → no-op para APIs sem layer (seguro para todos os consumidores).
- Diff vs base = apenas sufixo `-layer` no `name:` + o step acima.

## Próximo passo (fora deste PR)

Após o merge, apontar os jobs de stg/sbx/prd dos `*-pipeline.yml` do collections-api para os workflows `-layer` (hoje só o dev aponta).