### PR TITLE
[AR/AB#42748] feat(workflows): monorepo deploy workflows with scoped registry

### DIFF
--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
@@ -1,0 +1,129 @@
+name: monorepo-api-deploy-dev-layer-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_DEV:
+        required: true
+      DATABASE_PASSWORD_DEV:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_DEV:
+        required: false
+jobs:
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_DEV}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_DEV}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_DEV}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_DEV}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_DEV }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_DEV }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_DEV}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_DEV}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_DEV}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_DEV}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_DEV}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_DEV}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_DEV}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_DEV}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_DEV}}
+      ENV: ${{vars.ENV_DEV}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_DEV}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_DEV}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_DEV}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_DEV}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_DEV }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Development Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_DEV}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_DEV}}
+          export AWS_REGION=${{vars.AWS_REGION_DEV}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_DEV}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
@@ -1,0 +1,117 @@
+name: monorepo-api-deploy-dev-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_DEV:
+        required: true
+      DATABASE_PASSWORD_DEV:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_DEV:
+        required: false
+jobs:
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_DEV}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_DEV}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_DEV}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_DEV}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_DEV }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_DEV }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_DEV}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_DEV}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_DEV}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_DEV}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_DEV}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_DEV}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_DEV}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_DEV}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_DEV}}
+      ENV: ${{vars.ENV_DEV}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_DEV}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_DEV}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_DEV}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_DEV}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_DEV }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Development Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_DEV}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_DEV}}
+          export AWS_REGION=${{vars.AWS_REGION_DEV}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_DEV}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
@@ -1,0 +1,118 @@
+name: monorepo-api-deploy-prd-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_PRD:
+        required: true
+      DATABASE_PASSWORD_PRD:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_PRD:
+        required: false
+jobs:
+  deploy-prd:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_PRD}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_PRD}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_PRD}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_PRD}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_PRD }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_PRD }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_PRD}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_PRD}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_PRD}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_PRD}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_PRD}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_PRD}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_PRD}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_PRD}}
+      DD_API_KEY: ${{secrets.DD_API_KEY}}
+      DD_ENABLED: ${{vars.DD_ENABLED_PRD}}
+      ENV: ${{vars.ENV_PRD}}
+      AWS_LAMBDA_EXEC_WRAPPER: '/opt/datadog_wrapper'
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_PRD}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_PRD}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_PRD}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_PRD}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_PRD }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_PRD }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_PRD }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_PRD }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Production Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_PRD}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_PRD}}
+          export AWS_REGION=${{vars.AWS_REGION_PRD}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_PRD}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
@@ -1,0 +1,129 @@
+name: monorepo-api-deploy-sbx-layer-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_SBX:
+        required: true
+      DATABASE_PASSWORD_SBX:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_SBX:
+        required: false
+jobs:
+  deploy-sbx:
+    if: github.ref == 'refs/heads/sbx'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_SBX}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_SBX}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_SBX}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_SBX}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_SBX }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_SBX }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_SBX}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_SBX}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_SBX}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_SBX}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_SBX}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_SBX}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_SBX}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_SBX}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_SBX}}
+      ENV: ${{vars.ENV_SBX}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_SBX}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_SBX}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_SBX}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_SBX}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_SBX }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Sandbox Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_SBX}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_SBX}}
+          export AWS_REGION=${{vars.AWS_REGION_SBX}}
+          npm i -g serverless
+          sls deploy --force --stage ${{vars.ENV_SBX}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
@@ -1,0 +1,117 @@
+name: monorepo-api-deploy-sbx-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_SBX:
+        required: true
+      DATABASE_PASSWORD_SBX:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_SBX:
+        required: false
+jobs:
+  deploy-sbx:
+    if: github.ref == 'refs/heads/sbx'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_SBX}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_SBX}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_SBX}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_SBX}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_SBX }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_SBX }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_SBX}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_SBX}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_SBX}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_SBX}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_SBX}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_SBX}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_SBX}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_SBX}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_SBX}}
+      ENV: ${{vars.ENV_SBX}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_SBX}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_SBX}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_SBX}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_SBX}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_SBX }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Sandbox Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_SBX}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_SBX}}
+          export AWS_REGION=${{vars.AWS_REGION_SBX}}
+          npm i -g serverless
+          sls deploy --force --stage ${{vars.ENV_SBX}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
@@ -1,0 +1,129 @@
+name: monorepo-api-deploy-stg-layer-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_STG:
+        required: true
+      DATABASE_PASSWORD_DEV:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_DEV:
+        required: false
+jobs:
+  deploy-stg:
+    if: github.ref == 'refs/heads/stg'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_DEV}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_DEV}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_DEV}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_DEV}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_DEV }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_DEV }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_DEV}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_DEV}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_DEV}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_STG}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_STG}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_STG}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_STG}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_STG}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_STG}}
+      ENV: ${{vars.ENV_STG}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_STG}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_STG}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_STG}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_STG}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_STG }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Staging Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_STG}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_STG}}
+          export AWS_REGION=${{vars.AWS_REGION_STG}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_STG}} --region $AWS_REGION

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
@@ -1,0 +1,117 @@
+name: monorepo-api-deploy-stg-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_STG:
+        required: true
+      DATABASE_PASSWORD_DEV:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_DEV:
+        required: false
+jobs:
+  deploy-stg:
+    if: github.ref == 'refs/heads/stg'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_DEV}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_DEV}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_DEV}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_DEV}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_DEV }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_DEV }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_DEV}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_DEV}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_DEV}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_STG}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_STG}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_STG}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_STG}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_STG}}
+      DD_API_KEY: ''
+      DD_ENABLED: ${{vars.DD_ENABLED_STG}}
+      ENV: ${{vars.ENV_STG}}
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_STG}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_STG}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_STG}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_STG}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_DEV }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_DEV }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_DEV }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_STG }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Staging Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_STG}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_STG}}
+          export AWS_REGION=${{vars.AWS_REGION_STG}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_STG}} --region $AWS_REGION


### PR DESCRIPTION
Adiciona a família `monorepo-api-deploy-aws-{dev,stg,sbx,prd}-with-scope-serverless4` (com variantes `-layer` em dev e sbx), espelhando os workflows monorepo atuais e trocando a configuração global de registry pelo step **Config Registry** por escopo (`@navega` no Artifactory, autenticado por `JF_ACCESS_TOKEN`).

O step `Install` preserva o comportamento monorepo (`cd ..`, `yarn install`, `yarn build`), necessário para que os yarn workspaces resolvam a partir da raiz do repositório.

Os workflows `monorepo-*-serverless4*.yml` existentes **não foram alterados** — nenhum consumidor atual é afetado.

Cada arquivo novo difere da sua origem em exatamente 15 linhas: `name`, `env.NPM_REGISTRY`, o step `Config Registry` e o `Install` sem a configuração antiga de registry.

Consumidores desta família (PRs do mesmo card, bloqueados até este merge):
- collections-api navega-com-vc/collections-api#2252 (sbx) / navega-com-vc/collections-api#2253 (dev) / navega-com-vc/collections-api#2254 (stg)
- organizations-portal-api navega-com-vc/organizations-portal-api#357 (sbx) / navega-com-vc/organizations-portal-api#358 (dev) / navega-com-vc/organizations-portal-api#359 (stg)

[AB#42748](https://dev.azure.com/Quandoprev/8516981d-6bf2-499b-9497-7d31c1119687/_workitems/edit/42748)