### PR TITLE
[AB#42748] fix(workflows): run npm config from workspace root to avoid ENOWORKSPACES

### DIFF
--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Config Registry
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
+          cd ..
           npm config set registry ${{ env.NPM_REGISTRY }}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 


### PR DESCRIPTION
## Problem

Deploy jobs using the new `monorepo-*-with-scope-serverless4*` workflows fail on the
**Config Registry** step:

```
npm error code ENOWORKSPACES
npm error This command does not support workspaces.
```

Reproduced on `dev` in both consumers after merge:
- `collections-api` run 30456711655
- `organizations-portal-api` run 30456721102

## Cause

`Config Registry` runs with `working-directory: ${{ inputs.WORKING_DIRECTORY }}`,
i.e. inside `collections/` / `upload-files/`, which are **yarn workspace members**.
npm refuses `npm config set` from a workspace member.

The step was extracted from the non-monorepo `api-deploy-aws-*-with-scope-serverless4.yml`,
where no `cd ..` is needed because those subprojects are standalone. The pre-existing
monorepo workflows ran the same `npm config set` calls **after `cd ..`**, in the same
step as `yarn install` — that `cd ..` was kept in `Install` but lost in the new step.

## Fix

Add `cd ..` as the first line of the `Config Registry` step in all 7 files, matching
what `monorepo-api-deploy-aws-*-serverless4.yml` already does in production.
`npm config set` writes to `~/.npmrc`, so the working directory does not change the
outcome — it only stops npm from treating the cwd as a workspace member.

## Note

This could not have been caught by the consumer PRs: the deploy jobs are guarded by
`if: github.ref == 'refs/heads/<env>'` and are always skipped on `pull_request`.
