### PR TITLE
[AB#42748] fix(workflows): restore Artifactory as default registry for unscoped packages

### DIFF
--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4-layer.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-dev-with-scope-serverless4.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4.yml
@@ -65,8 +65,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -82,7 +80,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4-layer.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-sbx-with-scope-serverless4.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')

--- a/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-stg-with-scope-serverless4.yml
@@ -64,8 +64,6 @@ jobs:
 
       SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
 
-      NPM_REGISTRY: https://registry.npmjs.org/
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           cd ..
-          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
           npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
 
           REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')


### PR DESCRIPTION
## Problem

After #82 fixed the `ENOWORKSPACES` error, the deploy jobs now fail one step later,
on `Install`, in **both** consumers:

```
error Couldn't find package "navega-serverless-route-handler@^0.0.5"
      required by "collections-core@1.0.0"       (collections-api,  run 30456711655)
      required by "op-upload-files-api@1.10.0"   (organizations-portal-api, run 30456721102)
      on the "npm" registry
```

## Cause

The scoped-registry change assumed every private package lives under `@navega/`.
`navega-serverless-route-handler` has **no scope** — `navega-` is just a name prefix.
Unscoped packages resolve through the *default* registry, which these workflows had
pointed at `registry.npmjs.org`, where the package does not exist (404).

Before the change the default registry was the Artifactory, which proxies npmjs, so
scoped and unscoped packages both resolved.

`navega-api` is unaffected by this and stays green because it does not depend on that
package.

## Fix

Point the default registry back at the Artifactory and keep `@navega:registry` plus the
`JF_ACCESS_TOKEN` auth. This preserves the security goal of [AB#42748](https://dev.azure.com/Quandoprev/8516981d-6bf2-499b-9497-7d31c1119687/_workitems/edit/42748) (`_authToken`
instead of the deprecated global `_auth`) and restores unscoped resolution.

The now-unused `NPM_REGISTRY` env var is removed from these 7 files.

## Scope

Only the `monorepo-*-with-scope-*` family — the one that broke. The non-monorepo
`api-deploy-aws-*-with-scope-serverless4.yml` files carry the same assumption but have
no consumers yet; worth revisiting before anyone adopts them.

Migrating `navega-serverless-route-handler` to `@navega/serverless-route-handler` would
allow moving the default back to npmjs, and is better handled as its own card.
