### PR TITLE
[AB#42748] feat(workflows): support WORKING_DIRECTORY in lib-deploy-with-scope-main

### DIFF
--- a/.github/workflows/lib-deploy-with-scope-main.yml
+++ b/.github/workflows/lib-deploy-with-scope-main.yml
@@ -2,11 +2,20 @@ name: lib-deploy-with-scope-main
 
 on:
   workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+        required: false
+        default: .
 
 jobs:
   deploy-lib:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/BETA'
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
 
     env:
       NPM_REGISTRY: https://registry.npmjs.org/


### PR DESCRIPTION
## Problem

`navega-serverless-plugins` is a monorepo (the package lives in `serverless-route-handler/`,
there is no `package.json` at the root). Pointing it at this workflow fails validation:

```
Invalid workflow file: .github/workflows/serverless-route-handler.yml (Line: 23, Col: 26)
Invalid input, WORKING_DIRECTORY is not defined in the referenced workflow.
```

`lib-deploy-with-scope-main.yml` declared no inputs at all — it assumed the package sits
at the repository root, which holds for `navega-api` but not for a plugins monorepo.

## Change

- declare an optional `WORKING_DIRECTORY` input, defaulting to `.`
- apply it via `defaults.run.working-directory`, so every `run` step (install, build,
  publish, tag) executes in the package folder

Declaring the input alone would make the file valid but leave `npm install` running at
the root, where there is no `package.json`.

## Compatibility

`navega-api` does not pass the input, so it resolves to `.` — byte-for-byte the current
behaviour. `uses:` steps are unaffected by `defaults.run`.