### PR TITLE
ci: add prd deploy workflow with scoped registry and lambda layer

### DIFF
--- a/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4-layer.yml
+++ b/.github/workflows/monorepo-api-deploy-aws-prd-with-scope-serverless4-layer.yml
@@ -1,0 +1,131 @@
+name: monorepo-api-deploy-prd-layer-with-scope
+
+on:
+  workflow_call:
+    inputs:
+      WORKING_DIRECTORY:
+        type: string
+      RUNS_ON:
+        type: string
+        default: ubuntu-latest
+    secrets:
+      ARTIFACTORY_AUTH:
+        required: true
+      AWS_SECRET_ACCESS_KEY_PRD:
+        required: true
+      DATABASE_PASSWORD_PRD:
+        required: false
+      DD_API_KEY:
+        required: true
+      KEYCLOAK_PASSWORD_ADMIN_PRD:
+        required: false
+jobs:
+  deploy-prd:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ inputs.RUNS_ON }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      DATABASE_HOST: ${{vars.DATABASE_HOST_PRD}}
+      DATABASE_USERNAME: ${{vars.DATABASE_USERNAME_PRD}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD_PRD}}
+      DATABASE_NAME: ${{vars.DATABASE_NAME_PRD}}
+
+      DATABASE_DATA_SOURCE: ${{ vars.DATABASE_DATA_SOURCE_PRD }}
+      DATABASE_API_URL: ${{ vars.DATABASE_API_URL }}
+      DATABASE_API_KEY: ${{ secrets.DATABASE_API_KEY_PRD }}
+
+      KEYCLOAK_URL: ${{vars.KEYCLOAK_URL_PRD}}
+      KEYCLOAK_USERNAME_ADMIN: ${{vars.KEYCLOAK_USERNAME_ADMIN_PRD}}
+      KEYCLOAK_PASSWORD_ADMIN: ${{secrets.KEYCLOAK_PASSWORD_ADMIN_PRD}}
+
+      SUBNET_APP_A: ${{vars.SUBNET_APP_A_PRD}}
+      SUBNET_APP_B: ${{vars.SUBNET_APP_B_PRD}}
+      SECURITY_GROUP_API: ${{vars.SECURITY_GROUP_API_PRD}}
+
+      NAVEGA_API_URL: ${{vars.NAVEGA_API_URL_PRD}}
+
+      LOG_LEVEL: ${{vars.LOG_LEVEL_PRD}}
+      DD_API_KEY: ${{secrets.DD_API_KEY}}
+      DD_ENABLED: ${{vars.DD_ENABLED_PRD}}
+      ENV: ${{vars.ENV_PRD}}
+      AWS_LAMBDA_EXEC_WRAPPER: '/opt/datadog_wrapper'
+      WARMUP_ENABLED: ${{vars.WARMUP_ENABLED_PRD}}
+
+      AWS_DYNAMODB_REGION: ${{vars.AWS_REGION_PRD}}
+      AWS_DYNAMODB_VERSION: ${{vars.AWS_DYNAMODB_VERSION_PRD}}
+      AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE: ${{vars.AWS_DYNAMODB_MIRRORED_DOCUMENTS_TABLE_PRD}}
+
+      EMAIL_PROVIDER: ${{ vars.EMAIL_PROVIDER_PRD }}
+      EMAIL_USERNAME: ${{ vars.EMAIL_USERNAME_PRD }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD_PRD }}
+      EMAIL_REDIRECT_ADDRESS: ${{ secrets.EMAIL_REDIRECT_ADDRESS }}
+
+      SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_LICENSE_KEY_ERP }}
+
+      NPM_REGISTRY: https://registry.npmjs.org/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Config Registry
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          npm config set registry ${{ env.NPM_REGISTRY }}
+          npm config set @navega:registry ${{vars.ARTIFACTORY_NPM_REGISTRY}}
+
+          REGISTRY_PATH=$(echo "${{vars.ARTIFACTORY_NPM_REGISTRY}}" | sed 's|https://||')
+          npm config set //$REGISTRY_PATH:_authToken=${{secrets.JF_ACCESS_TOKEN_BACKEND}}
+
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Install
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          cd ..
+          cp ~/.npmrc ./.npmrc
+          yarn install
+          yarn build
+
+      - name: Install layer dependencies
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          # Install dependencies in subdirectories of 'layer'
+          if [ -d "layer" ]; then
+            for dir in layer/*/; do
+              if [ -f "$dir/package.json" ]; then
+                (cd "$dir" && yarn install)
+              fi
+            done
+          fi
+
+      - name: Run migrations
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          if [ -f "migrate-mongo-config.js" ]; then
+            echo "migrate-mongo-config.js found — running migrations..."
+            yarn navega-migrate-cli up ${{ vars.ENV_PRD }}
+          else
+            echo "No migrate-mongo-config.js file found — skipping migrations."
+          fi
+
+      - name: Production Deploy
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+        run: |
+          export VERSION=$(node -p "require('./package.json').version")
+          export AWS_ACCESS_KEY_ID=${{vars.AWS_ACCESS_KEY_ID_PRD}}
+          export AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY_PRD}}
+          export AWS_REGION=${{vars.AWS_REGION_PRD}}
+          npm i -g serverless
+          sls deploy --stage ${{vars.ENV_PRD}} --region $AWS_REGION


### PR DESCRIPTION
## Problema

O workflow `monorepo-api-deploy-aws-prd-with-scope-serverless4.yml` não tem o step
**Install layer dependencies**. Serviços que externalizam as dependências de runtime
para uma lambda layer (`layer/nodejs/package.json` + `esbuild-node-externals`)
publicam em produção uma layer contendo apenas o `package.json`, sem `node_modules`.

O resultado é falha no cold start de todas as lambdas do serviço:

```
{"errorType":"Runtime.ImportModuleError",
 "errorMessage":"Error: Cannot find module '@navega/api-toolkit'"}
```

Foi exatamente o que aconteceu com o `contributions-api` em PRD.

## Por que só o prd

As três combinações vizinhas já existem — só a de produção com escopo faltava:

| ambiente | with-scope | with-scope + layer |
|---|---|---|
| dev | ✅ | ✅ |
| stg | ✅ | ✅ |
| sbx | ✅ | ✅ |
| prd | ✅ | ❌ **este PR** |

Por isso `dev`, `stg` e `sbx` puderam ser corrigidos nos repositórios consumidores e
o `prd` não: não havia workflow para apontar.

## O que este PR faz

Adiciona `monorepo-api-deploy-aws-prd-with-scope-serverless4-layer.yml`, que é uma
cópia de `monorepo-api-deploy-aws-prd-with-scope-serverless4.yml` mais o mesmo step
de instalação de layer já usado em dev/stg/sbx, posicionado entre `Install` e
`Run migrations`:

```yaml
- name: Install layer dependencies
  working-directory: ${{ inputs.WORKING_DIRECTORY }}
  run: |
    # Install dependencies in subdirectories of 'layer'
    if [ -d "layer" ]; then
      for dir in layer/*/; do
        if [ -f "$dir/package.json" ]; then
          (cd "$dir" && yarn install)
        fi
      done
    fi
```

O step é um no-op para serviços sem diretório `layer/`, então a variante é segura
para qualquer consumidor.

O diff em relação ao workflow existente é apenas o `name:` e essas 12 linhas —
nenhuma variável de ambiente, secret ou input foi alterado.

## Validação

- YAML parseia; `on: workflow_call`, guard `if: github.ref == 'refs/heads/main'` e a
  ordem dos steps preservados (Checkout → Setup Node → Config Registry → Install →
  **Install layer dependencies** → Run migrations → Production Deploy).
- Diff estrutural contra `monorepo-api-deploy-aws-stg-with-scope-serverless4-layer.yml`
  contém somente as diferenças de ambiente (STG → PRD).

## Consumidor

`navega-com-vc/collections-api` tem PR pronto apontando o `deploy-prd` dos 5 módulos
(balance, collections, configurations, contributions, processes) para este workflow.
Ele depende deste merge.
